### PR TITLE
Back fill from MCT

### DIFF
--- a/.github/prompts/dotnet/codestyle.prompt.md
+++ b/.github/prompts/dotnet/codestyle.prompt.md
@@ -613,3 +613,51 @@ public async Task ShowAlertAsync(string message, CancellationToken token = defau
 		}
 	}
 	```
+
+### Methods Returning Task and ValueTask
+- **Good Practice**: Include a `CancellationToken` as a parameter for methods returning `Task` or `ValueTask`.
+- **Bad Practice**: Not including a `CancellationToken`.
+
+```csharp
+// Good Practice
+public async Task LoadDataAsync(CancellationToken token = default)
+{
+	token.ThrowIfCancellationRequested();
+	// Method implementation
+}
+
+// Bad Practice
+public async Task LoadDataAsync()
+{
+	// Method implementation
+}
+```
+
+### Pattern Matching
+- **Good Practice**: Use `is` for null checking and type checking.
+- **Bad Practice**: Using `==` for null checking or casting for type checking.
+
+```csharp
+// Good Practice
+if (something is null)
+{
+	// Handle null
+}
+
+if (something is Bucket bucket)
+{
+	bucket.Empty();
+}
+
+// Bad Practice
+if (something == null)
+{
+	// Handle null
+}
+
+var bucket = something as Bucket;
+if (bucket != null)
+{
+	bucket.Empty();
+}
+```

--- a/.github/prompts/dotnet/codestyle.prompt.md
+++ b/.github/prompts/dotnet/codestyle.prompt.md
@@ -1,0 +1,577 @@
+# Coding Style Guide
+This guide provides a set of best practices and coding standards for writing C# code with GitHub Copilot. It covers various aspects of C# programming, including naming conventions, code structure, control flow, nullability, safe operations, asynchronous programming, and symbol references.
+
+## XML document Comments:
+Add missing XML Doc Comments and mention the purpose, intent, and 'the why' of the code, so developers unfamiliar with the project can better understand it. If comments already exist, update them to meet the before mentioned criteria if needed. Use the full syntax of XML Doc Comments to make them as awesome as possible including references to types. Don't add any documentation that is obvious for even novice developers by reading the code.
+
+## Type Definitions:
+- Prefer records for data types:
+	```csharp
+	// Good: Immutable data type with value semantics
+	public sealed record CustomerDto(string Name, Email Email);
+	
+	// Avoid: Class with mutable properties
+	public class Customer
+	{
+		public string Name { get; set; }
+		public string Email { get; set; }
+	}
+	```
+- Make classes sealed by default:
+	```csharp
+	// Good: Sealed by default
+	public sealed class OrderProcessor
+	{
+		// Implementation
+	}
+	
+	// Only unsealed when inheritance is specifically designed for
+	public abstract class Repository<T>
+	{
+		// Base implementation
+	}
+	```
+
+## Control Flow:
+- Prefer range indexers over LINQ:
+	```csharp
+	// Good: Using range indexers with clear comments
+	var lastItem = items[^1];  // ^1 means "1 from the end"
+	var firstThree = items[..3];  // ..3 means "take first 3 items"
+	var slice = items[2..5];  // take items from index 2 to 4 (5 exclusive)
+	
+	// Avoid: Using LINQ when range indexers are clearer
+	var lastItem = items.LastOrDefault();
+	var firstThree = items.Take(3).ToList();
+	var slice = items.Skip(2).Take(3).ToList();
+	```
+- Prefer collection initializers:
+	```csharp
+	// Good: Using collection initializers
+	string[] fruits = ["Maui", "Community", "Toolkit"];
+	
+	// Avoid: Using explicit initialization when type is clear
+	var fruits = new List<int>() {
+		"Maui",
+		"Community",
+		"Toolkit"
+	};
+	```
+- Use pattern matching effectively:
+	```csharp
+	// Good: Clear pattern matching
+	static bool TryGetModalPageButton(Microsoft.Maui.ILayout layout, [NotNullWhen(true)] out Button? button)
+	{
+		button = null;
+
+		foreach (var view in layout)
+		{
+			switch (view)
+			{
+				case Button { Text: tryStatusBarOnModalPageButtonText } modalPageButton:
+					button = modalPageButton;
+					return true;
+
+				case Microsoft.Maui.ILayout nestedLayout:
+					if (TryGetModalPageButton(nestedLayout, out var modalPageButtonInLayout))
+					{
+						button = modalPageButtonInLayout;
+						return true;
+					}
+					break;
+			}
+		}
+
+		return false;
+	}
+	
+	// Avoid: Nested if statements
+	static bool TryGetModalPageButton(Microsoft.Maui.ILayout layout, [NotNullWhen(true)] out Button? button)
+	{
+		button = null;
+
+		foreach (var view in layout)
+		{
+			if (view is Button { Text: tryStatusBarOnModalPageButtonText } modalPageButton)
+			{
+				button = modalPageButton;
+				return true;
+			}
+			else if (view is Microsoft.Maui.ILayout nestedLayout)
+			{
+				if (TryGetModalPageButton(nestedLayout, out var modalPageButtonInLayout))
+				{
+					button = modalPageButtonInLayout;
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+	```
+
+## Nullability:
+- Mark nullable fields explicitly:
+	```csharp
+	// Good: Explicit nullability
+	public partial class MaskedBehavior : BaseBehavior<InputView>, IDisposable
+	{
+		IReadOnlyDictionary<int, char>? maskPositions;
+ 
+		void SetMaskPositions(in string? mask)
+		{
+			if (string.IsNullOrEmpty(mask))
+			{
+				maskPositions = null;
+				return;
+			}
+
+			var list = new Dictionary<int, char>();
+
+			for (var i = 0; i < mask.Length; i++)
+			{
+				if (mask[i] != UnmaskedCharacter)
+				{
+					list.Add(i, mask[i]);
+				}
+			}
+
+			maskPositions = list;
+		}
+	}
+
+	// Avoid: Implicit nullability
+	public partial class MaskedBehavior : BaseBehavior<InputView>, IDisposable
+	{
+		IReadOnlyDictionary<int, char> maskPositions; // Warning: Could be null
+		private string lastPosition; // Warning: Could be null
+	}
+	```
+- Use null checks only when necessary for reference types and public methods:
+	```csharp
+	// Good: Proper null checking
+	void HandleButtonClicked(object? sender, EventArgs e)
+	{
+		ArgumentNullException.ThrowIfNull(sender);
+		var button = (Button)sender;
+		button.Behaviors.Add(new IconTintColorBehavior
+		{
+			TintColor = Colors.Green
+		});
+	}
+	
+	// Good: Using pattern matching for null checks
+	void OnRegexPropertyChanged(string? regexPattern, RegexOptions regexOptions) => regex = regexPattern switch
+	{
+		null => null,
+		_ => new Regex(regexPattern, regexOptions)
+	};
+
+	// Avoid: null checks for value types
+	public void ProcessOrder(int orderId)
+	{
+		ArgumentNullException.ThrowIfNull(orderId);
+	}
+
+	// Avoid: null checks for non-public methods
+	private void ProcessOrder(Order order)
+	{
+		ArgumentNullException.ThrowIfNull(order);
+	}
+	```
+- Use null-forgiving operator only when appropriate:
+	```csharp
+	public class OrderValidator
+	{
+		private readonly IValidator<Order> _validator;
+		
+		public OrderValidator(IValidator<Order> validator)
+		{
+			_validator = validator ?? throw new ArgumentNullException(nameof(validator));
+		}
+		
+		public ValidationResult Validate(Order order)
+		{
+			// We know _validator can't be null due to constructor check
+			return _validator!.Validate(order);
+		}
+	}
+	```
+- Use nullability attributes:
+	```csharp
+	[AcceptEmptyServiceProvider]
+	public partial class ImageResourceConverter : BaseConverterOneWay<string?, ImageSource?>
+	{
+		[return: NotNullIfNotNull(nameof(value))]
+		public override ImageSource? ConvertFrom(string? value, CultureInfo? culture = null) => value switch
+		{
+			null => null,
+			_ => ImageSource.FromResource(value, Application.Current?.GetType().Assembly)
+		};
+		
+		// Method never returns null
+		[return: NotNull]
+		public static string EnsureNotNull(string? input) =>
+			input ?? string.Empty;
+		
+		// Parameter must not be null when method returns true
+		public static bool TryParse(string? input, [NotNullWhen(true)] out string? result)
+		{
+			result = null;
+			if (string.IsNullOrEmpty(input))
+				return false;
+				
+			result = input;
+			return true;
+		}
+	}
+	```
+- Use init-only properties with non-null validation:
+	```csharp
+	// Good: Non-null validation in constructor
+	public class AvatarModel
+	{
+		public Color BackgroundColor { get; init; } = Colors.Black;
+		public Color BorderColor { get; init; } = Colors.White;
+		
+		public AvatarModel()
+		{
+			BackgroundColor = null!; // Will be set by required property
+			BorderColor = null!; // Will be set by required property
+		}
+		
+		private AvatarModel(Color backgroundColor, Color borderColor)
+		{
+			BackgroundColor = backgroundColor;
+			BorderColor = borderColor;
+		}
+		
+		public static AvatarModel Create(Color backgroundColor, Color borderColor) =>
+			new(backgroundColor, borderColor);
+	}
+	```
+- Document nullability in interfaces:
+	```csharp
+	public interface IOrderRepository
+	{
+		// Explicitly shows that null is a valid return value
+		Task<Order?> FindByIdAsync(OrderId id, CancellationToken ct = default);
+		
+		// Method will never return null
+		[return: NotNull]
+		Task<IReadOnlyList<Order>> GetAllAsync(CancellationToken ct = default);
+		
+		// Parameter cannot be null
+		Task SaveAsync([NotNull] Order order, CancellationToken ct = default);
+	}
+	```
+
+## Safe Operations:
+- Use Try methods for safer operations:
+	```csharp
+	// Good: Using TryGetValue for dictionary access
+	if (dictionary.TryGetValue(key, out var value))
+	{
+		// Use value safely here
+	}
+	else
+	{
+		// Handle missing key case
+	}
+	```
+	```csharp
+	// Avoid: Direct indexing which can throw
+	var value = dictionary[key];  // Throws if key doesn't exist
+
+	// Good: Using Uri.TryCreate for URL parsing
+	if (Uri.TryCreate(urlString, UriKind.Absolute, out var uri))
+	{
+		// Use uri safely here
+	}
+	else
+	{
+		// Handle invalid URL case
+	}
+	```
+	```csharp
+	// Avoid: Direct Uri creation which can throw
+	var uri = new Uri(urlString);  // Throws on invalid URL
+
+	// Good: Using int.TryParse for number parsing
+	if (int.TryParse(input, out var number))
+	{
+		// Use number safely here
+	}
+	else
+	{
+		// Handle invalid number case
+	}
+	```
+	```csharp
+	// Good: Combining Try methods with null coalescing
+	var value = dictionary.TryGetValue(key, out var result)
+		? result
+		: defaultValue;
+
+	// Good: Using Try methods in LINQ with pattern matching
+	var validNumbers = strings
+		.Select(s => (Success: int.TryParse(s, out var num), Value: num))
+		.Where(x => x.Success)
+		.Select(x => x.Value);
+	```
+
+- Prefer Try methods over exception handling:
+	```csharp
+	// Good: Using Try method
+	if (decimal.TryParse(priceString, out var price))
+	{
+		// Process price
+	}
+
+	// Avoid: Exception handling for expected cases
+	try
+	{
+		var price = decimal.Parse(priceString);
+		// Process price
+	}
+	catch (FormatException)
+	{
+		// Handle invalid format
+	}
+	```
+
+## Asynchronous Programming:
+- Use Task.FromResult for pre-computed values:
+	```csharp
+	// Good: Return pre-computed value
+	public Task<int> GetDefaultQuantityAsync() =>
+		Task.FromResult(1);
+	
+	// Better: Use ValueTask for zero allocations
+	public ValueTask<int> GetDefaultQuantityAsync() =>
+		new ValueTask<int>(1);
+	
+	// Avoid: Unnecessary thread pool usage
+	public Task<int> GetDefaultQuantityAsync() =>
+		Task.Run(() => 1);
+	```
+- Always flow CancellationToken:
+	```csharp
+	// Good: Propagate cancellation
+	public async Task<Order> ProcessOrderAsync(
+		OrderRequest request,
+		CancellationToken cancellationToken)
+	{
+		var order = await _repository.GetAsync(
+			request.OrderId, 
+			cancellationToken);
+			
+		await _processor.ProcessAsync(
+			order, 
+			cancellationToken);
+			
+		return order;
+	}
+	```
+- Prefer await:
+	```csharp
+	// Good: Using await
+	public async Task<Order> ProcessOrderAsync(OrderId id)
+	{
+		var order = await _repository.GetAsync(id);
+		await _validator.ValidateAsync(order);
+		return order;
+	}
+	```
+- Never use Task.Result or Task.Wait:
+	```csharp
+	// Good: Async all the way
+	public async Task<Order> GetOrderAsync(OrderId id)
+	{
+		return await _repository.GetAsync(id);
+	}
+	
+	// Avoid: Blocking on async code
+	public Order GetOrder(OrderId id)
+	{
+		return _repository.GetAsync(id).Result; // Can deadlock
+	}
+	```
+- Use TaskCompletionSource correctly:
+	```csharp
+	// Good: Using RunContinuationsAsynchronously
+	private readonly TaskCompletionSource<Order> _tcs = 
+		new(TaskCreationOptions.RunContinuationsAsynchronously);
+	
+	// Avoid: Default TaskCompletionSource can cause deadlocks
+	private readonly TaskCompletionSource<Order> _tcs = new();
+	```
+- Always dispose CancellationTokenSources:
+	```csharp
+	// Good: Proper disposal of CancellationTokenSource
+	public async Task<Order> GetOrderWithTimeout(OrderId id)
+	{
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+		return await _repository.GetAsync(id, cts.Token);
+	}
+	```
+- Prefer async/await over direct Task return:
+	```csharp
+	// Good: Using async/await
+	public async Task<Order> ProcessOrderAsync(OrderRequest request)
+	{
+		await _validator.ValidateAsync(request);
+		var order = await _factory.CreateAsync(request);
+		return order;
+	}
+	
+	// Avoid: Manual task composition
+	public Task<Order> ProcessOrderAsync(OrderRequest request)
+	{
+		return _validator.ValidateAsync(request)
+			.ContinueWith(t => _factory.CreateAsync(request))
+			.Unwrap();
+	}
+	```
+
+## Symbol References:
+- Always use nameof operator:
+	```csharp
+	// Good: Using nameof in attributes
+	public class OrderProcessor
+	{
+		[Required(ErrorMessage = "The {0} field is required")]
+		[Display(Name = nameof(OrderId))]
+		public string OrderId { get; init; }
+		
+		[MemberNotNull(nameof(_repository))]
+		private void InitializeRepository()
+		{
+			_repository = new OrderRepository();
+		}
+		
+		[NotifyPropertyChangedFor(nameof(FullName))]
+		public string FirstName
+		{
+			get => _firstName;
+			set => SetProperty(ref _firstName, value);
+		}
+	}
+	```
+- Use nameof with exceptions:
+	```csharp
+	public class OrderService
+	{
+		public async Task<Order> GetOrderAsync(OrderId id, CancellationToken ct)
+		{
+			var order = await _repository.FindAsync(id, ct);
+			
+			if (order is null)
+				throw new OrderNotFoundException(
+					$"Order with {nameof(id)} '{id}' not found");
+					
+			if (!order.Lines.Any())
+				throw new InvalidOperationException(
+					$"{nameof(order.Lines)} cannot be empty");
+					
+			return order;
+		}
+		
+		public void ValidateOrder(Order order)
+		{
+			if (order.Lines.Count == 0)
+				throw new ArgumentException(
+					"Order must have at least one line",
+					nameof(order));
+		}
+	}
+	```
+- Use nameof in logging:
+	```csharp
+	public class OrderProcessor
+	{
+		private readonly ILogger<OrderProcessor> _logger;
+		
+		public async Task ProcessAsync(Order order)
+		{
+			_logger.LogInformation(
+				"Starting {Method} for order {OrderId}",
+				nameof(ProcessAsync),
+				order.Id);
+				
+			try
+			{
+				await ProcessInternalAsync(order);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(
+					ex,
+					"Error in {Method} for {Property} {Value}",
+					nameof(ProcessAsync),
+					nameof(order.Id),
+					order.Id);
+				throw;
+			}
+		}
+	}
+	```
+
+### Usings and Namespaces:
+- Use implicit usings:
+	```csharp
+	// Good: Implicit
+	namespace MyNamespace
+	{
+		public class MyClass
+		{
+			// Implementation
+		}
+	}
+	// Avoid:
+	using System; // DON'T USE
+	using System.Collections.Generic; // DON'T USE
+	using System.IO; // DON'T USE
+	using System.Linq; // DON'T USE
+	using System.Net.Http; // DON'T USE
+	using System.Threading; // DON'T USE
+	using System.Threading.Tasks;// DON'T USE
+	using System.Net.Http.Json; // DON'T USE
+	using Microsoft.AspNetCore.Builder; // DON'T USE
+	using Microsoft.AspNetCore.Hosting; // DON'T USE
+	using Microsoft.AspNetCore.Http; // DON'T USE
+	using Microsoft.AspNetCore.Routing; // DON'T USE
+	using Microsoft.Extensions.Configuration; // DON'T USE
+	using Microsoft.Extensions.DependencyInjection; // DON'T USE
+	using Microsoft.Extensions.Hosting; // DON'T USE
+	using Microsoft.Extensions.Logging; // DON'T USE
+	using Good: Explicit usings; // DON'T USE
+	
+	namespace MyNamespace
+	{
+		public class MyClass
+		{
+			// Implementation
+		}
+	}
+	```
+- Use file-scoped namespaces:
+	```csharp
+	// Good: File-scoped namespace
+	namespace MyNamespace;
+	
+	public class MyClass
+	{
+		// Implementation
+	}
+	
+	// Avoid: Block-scoped namespace
+	namespace MyNamespace
+	{
+		public class MyClass
+		{
+			// Implementation
+		}
+	}
+	```

--- a/.github/prompts/dotnet/codestyle.prompt.md
+++ b/.github/prompts/dotnet/codestyle.prompt.md
@@ -4,6 +4,44 @@ This guide provides a set of best practices and coding standards for writing C# 
 ## XML document Comments:
 Add missing XML Doc Comments and mention the purpose, intent, and 'the why' of the code, so developers unfamiliar with the project can better understand it. If comments already exist, update them to meet the before mentioned criteria if needed. Use the full syntax of XML Doc Comments to make them as awesome as possible including references to types. Don't add any documentation that is obvious for even novice developers by reading the code.
 
+- **Good Practice**: Provide XML documentation for public members.
+- **Bad Practice**: Not providing documentation or leaving it empty.
+
+```csharp
+// Good Practice
+/// <summary>
+/// Displays an alert with the specified message.
+/// </summary>
+/// <param name="message">The message to display.</param>
+/// <param name="token">The cancellation token.</param>
+public async Task ShowAlertAsync(string message, CancellationToken token = default)
+{
+	try
+	{
+		token.ThrowIfCancellationRequested();
+		await _alertService.ShowAlertAsync(message, token);
+	}
+	catch (Exception ex)
+	{
+		Trace.WriteLine($"Error displaying alert: {ex.Message}");
+	}
+}
+
+// Bad Practice
+public async Task ShowAlertAsync(string message, CancellationToken token = default)
+{
+	try
+	{
+		token.ThrowIfCancellationRequested();
+		await _alertService.ShowAlertAsync(message, token);
+	}
+	catch (Exception ex)
+	{
+		Trace.WriteLine($"Error displaying alert: {ex.Message}");
+	}
+}
+```
+
 ## Type Definitions:
 - Prefer records for data types:
 	```csharp

--- a/.github/prompts/dotnet/maui/maui-layouts.prompt.md
+++ b/.github/prompts/dotnet/maui/maui-layouts.prompt.md
@@ -5,3 +5,33 @@ A flatter visual tree is better since it reduces the number of measure and arran
 ## Guidelines
 
 Do not nest scrollable controls (ScrollView, CollectionView, ListView) within each other unless they scroll in different directions. It is OK to nest within a RefreshView or similar pull-to-refresh control.
+
+### Handling Layout Changes
+- **Good Practice**: Override `OnSizeAllocated` to handle layout changes and adjust child elements accordingly.
+- **Bad Practice**: Not handling layout changes or using event handlers for layout changes.
+
+```csharp
+// Good Practice
+public class CustomLayout : StackLayout
+{
+    protected override void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+        // Adjust child elements based on new size
+    }
+}
+
+// Bad Practice
+public class CustomLayout : StackLayout
+{
+    public CustomLayout()
+    {
+        SizeChanged += OnSizeChanged;
+    }
+
+    private void OnSizeChanged(object sender, EventArgs e)
+    {
+        // Adjust child elements based on new size
+    }
+}
+```

--- a/.github/prompts/dotnet/maui/maui.prompt.md
+++ b/.github/prompts/dotnet/maui/maui.prompt.md
@@ -50,6 +50,25 @@ builder.ConfigureMauiHandlers(handlers =>
 }
 ```
 
+## UI Components and Controls
+- **Good Practice**: Ensure that any UI components or controls are compatible with .NET MAUI.
+- **Bad Practice**: Using Xamarin.Forms-specific code unless there is a direct .NET MAUI equivalent.
+
+```csharp
+// Good Practice
+public class CustomButton : Button
+{
+    // .NET MAUI specific implementation
+}
+
+// Bad Practice
+public class CustomButton : Xamarin.Forms.Button
+{
+    // Xamarin.Forms specific implementation
+}
+```
+
+
 # Additional prompts
 
 Read these additional prompts when you doing work related to the link's name:

--- a/.github/prompts/dotnet/maui/maui.prompt.md
+++ b/.github/prompts/dotnet/maui/maui.prompt.md
@@ -51,6 +51,7 @@ builder.ConfigureMauiHandlers(handlers =>
 ```
 
 ## UI Components and Controls
+
 - **Good Practice**: Ensure that any UI components or controls are compatible with .NET MAUI.
 - **Bad Practice**: Using Xamarin.Forms-specific code unless there is a direct .NET MAUI equivalent.
 
@@ -68,6 +69,191 @@ public class CustomButton : Xamarin.Forms.Button
 }
 ```
 
+## Handling Permissions
+
+- **Good Practice**: Use `Permissions` API to request and check permissions.
+- **Bad Practice**: Not handling permissions or using platform-specific code.
+
+```csharp
+// Good Practice
+public async Task<PermissionStatus> CheckAndRequestLocationPermissionAsync()
+{
+    var status = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
+    if (status != PermissionStatus.Granted)
+    {
+        status = await Permissions.RequestAsync<Permissions.LocationWhenInUse>();
+    }
+    return status;
+}
+
+// Bad Practice
+public async Task<bool> CheckAndRequestLocationPermissionAsync()
+{
+#if ANDROID
+    var status = ContextCompat.CheckSelfPermission(Android.App.Application.Context, Manifest.Permission.AccessFineLocation);
+    if (status != Permission.Granted)
+    {
+        ActivityCompat.RequestPermissions(MainActivity.Instance, new[] { Manifest.Permission.AccessFineLocation }, 0);
+    }
+    return status == Permission.Granted;
+#elif IOS
+    var status = CLLocationManager.Status;
+    if (status != CLAuthorizationStatus.AuthorizedWhenInUse)
+    {
+        locationManager.RequestWhenInUseAuthorization();
+    }
+    return status == CLAuthorizationStatus.AuthorizedWhenInUse;
+#endif
+}
+```
+
+## Using Dependency Injection
+
+- **Good Practice**: Use dependency injection to manage dependencies and improve testability.
+- **Bad Practice**: Creating instances of dependencies directly within the class.
+
+```csharp
+// Good Practice
+public class LocationService
+{
+    private readonly IGeolocation _geolocation;
+
+    public LocationService(IGeolocation geolocation)
+    {
+        _geolocation = geolocation ?? throw new ArgumentNullException(nameof(geolocation));
+    }
+
+    public async Task<Location> GetLocationAsync(CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        return await _geolocation.GetLocationAsync(new GeolocationRequest(), token);
+    }
+}
+
+// Bad Practice
+public class LocationService
+{
+    private readonly IGeolocation _geolocation = new Geolocation();
+
+    public async Task<Location> GetLocationAsync(CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        return await _geolocation.GetLocationAsync(new GeolocationRequest(), token);
+    }
+}
+```
+
+## Image Source Initialization
+
+- **Good Practice**: Use dependency injection to initialize image sources.
+- **Bad Practice**: Creating instances of image sources directly within the class.
+
+```csharp
+// Good Practice
+public class CustomImageSource
+{
+    private readonly IImageService _imageService;
+
+    public CustomImageSource(IImageService imageService)
+    {
+        _imageService = imageService ?? throw new ArgumentNullException(nameof(imageService));
+    }
+
+    public async Task<ImageSource> GetImageSourceAsync(string imageUrl, CancellationToken token = default)
+    {
+        token.ThrowIfCancellationRequested();
+        return await _imageService.LoadImageAsync(imageUrl, token);
+    }
+}
+
+// Bad Practice
+public class CustomImageSource
+{
+    private readonly IImageService _imageService = new ImageService();
+
+    public async Task<ImageSource> GetImageSourceAsync(string imageUrl)
+    {
+        return await _imageService.LoadImageAsync(imageUrl);
+    }
+}
+```
+
+## Handling Image Loading
+
+- **Good Practice**: Implement proper error handling and logging when loading images.
+- **Bad Practice**: Not handling exceptions or logging errors.
+
+```csharp
+// Good Practice
+public async Task<ImageSource> GetImageSourceAsync(string imageUrl, CancellationToken token = default)
+{
+    try
+    {
+        token.ThrowIfCancellationRequested();
+        return await _imageService.LoadImageAsync(imageUrl, token);
+    }
+    catch (Exception ex)
+    {
+        Trace.WriteLine($"Error loading image: {ex.Message}");
+        return null;
+    }
+}
+
+// Bad Practice
+public async Task<ImageSource> GetImageSourceAsync(string imageUrl)
+{
+    return await _imageService.LoadImageAsync(imageUrl);
+}
+```
+
+## Caching Image Sources
+
+- **Good Practice**: Use caching mechanisms to improve performance and reduce network usage.
+- **Bad Practice**: Not implementing caching for frequently used images.
+
+```csharp
+// Good Practice
+public class CachedImageSource
+{
+    private readonly IImageService _imageService;
+    private readonly IMemoryCache _cache;
+
+    public CachedImageSource(IImageService imageService, IMemoryCache cache)
+    {
+        _imageService = imageService ?? throw new ArgumentNullException(nameof(imageService));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+    }
+
+    public async Task<ImageSource> GetImageSourceAsync(string imageUrl, CancellationToken token = default)
+    {
+        if (_cache.TryGetValue(imageUrl, out ImageSource cachedImage))
+        {
+            return cachedImage;
+        }
+
+        token.ThrowIfCancellationRequested();
+        var imageSource = await _imageService.LoadImageAsync(imageUrl, token);
+        _cache.Set(imageUrl, imageSource);
+        return imageSource;
+    }
+}
+
+// Bad Practice
+public class CachedImageSource
+{
+    private readonly IImageService _imageService;
+
+    public CachedImageSource(IImageService imageService)
+    {
+        _imageService = imageService ?? throw new ArgumentNullException(nameof(imageService));
+    }
+
+    public async Task<ImageSource> GetImageSourceAsync(string imageUrl)
+    {
+        return await _imageService.LoadImageAsync(imageUrl);
+    }
+}
+```
 
 # Additional prompts
 

--- a/.github/prompts/dotnet/testing.xunit.prompt.md
+++ b/.github/prompts/dotnet/testing.xunit.prompt.md
@@ -1,0 +1,393 @@
+# Unit Testing
+The default unit testing framework for .NET projects is xUnit. This document provides guidelines for writing unit tests using xUnit.
+
+Tests should be reliable, maintainable, provide meaningful coverage, and provide proper isolation and clear patterns for test organization and execution.
+
+## Requirements
+- Use xUnit as the testing framework
+- Ensure test isolation
+- Follow consistent patterns
+- Maintain high code coverage
+
+## Test Class Structure:
+
+- Use ITestOutputHelper for logging:
+	```csharp
+	public class OnControlBindingContextChanged(ITestOutputHelper output)
+	{
+		
+		[Fact]
+		public async Task BindingContext_Changed()
+		{
+			output.WriteLine("Starting test with default binding context");
+			// Test implementation
+		}
+	}
+	```
+- Use fixtures for shared state:
+	```csharp
+	public class DatabaseFixture : IAsyncLifetime
+	{
+		public DbConnection Connection { get; private set; }
+		
+		public async Task InitializeAsync()
+		{
+			Connection = new SqlConnection("connection-string");
+			await Connection.OpenAsync();
+		}
+		
+		public async Task DisposeAsync()
+		{
+			await Connection.DisposeAsync();
+		}
+	}
+	
+	public class OrderTests : IClassFixture<DatabaseFixture>
+	{
+		private readonly DatabaseFixture _fixture;
+		private readonly ITestOutputHelper _output;
+		
+		public OrderTests(DatabaseFixture fixture, ITestOutputHelper output)
+		{
+			_fixture = fixture;
+			_output = output;
+		}
+	}
+	```
+
+## Test Methods:
+
+- Prefer Theory over multiple Facts:
+	```csharp
+	public class DiscountCalculatorTests
+	{
+		public static TheoryData<IComparable, IComparable, IComparable, object, object, object> TestData { get; } = new()
+		{
+			// System.Byte
+			{
+				Convert.ToByte('C'), Convert.ToByte('B'), Convert.ToByte('D'), TrueTestObject, FalseTestObject, TrueTestObject
+			},
+			{
+				Convert.ToByte('B'), Convert.ToByte('B'), Convert.ToByte('D'), TrueTestObject, FalseTestObject, TrueTestObject
+			},
+			{
+				Convert.ToByte('D'), Convert.ToByte('B'), Convert.ToByte('D'), TrueTestObject, FalseTestObject, TrueTestObject
+			},
+		};
+		
+		[Theory]
+		[MemberData(nameof(TestData))]
+		public void IsInRangeConverterConvertFrom(IComparable value, IComparable comparingMinValue, IComparable comparingMaxValue, object trueObject, object falseObject, object expectedResult)
+		{
+			// Arrange
+			IsInRangeConverter isInRangeConverter = new()
+			{
+				MinValue = comparingMinValue,
+				MaxValue = comparingMaxValue,
+				FalseObject = falseObject,
+				TrueObject = trueObject,
+			};
+
+			// Act
+			object? convertResult = ((ICommunityToolkitValueConverter)isInRangeConverter).Convert(value, typeof(object), null, CultureInfo.CurrentCulture);
+			object convertFromResult = isInRangeConverter.ConvertFrom(value, CultureInfo.CurrentCulture);
+
+			// Assert
+			Assert.Equal(expectedResult, convertResult);
+			Assert.Equal(expectedResult, convertFromResult);
+		}
+	}
+	```
+- Follow Arrange-Act-Assert pattern:
+	```csharp
+	[Fact]
+	public void ViewStructure_CorrectNumberOfChildren()
+	{
+		// Arrange
+		const int maximumRating = 3;
+		RatingView ratingView = new()
+		{
+			MaximumRating = maximumRating
+		};
+
+		// Act
+		var controlTemplate = ratingView.ControlTemplate;
+		var visualTreeDescendantsCount = ratingView.RatingLayout.GetVisualTreeDescendants().Count;
+		var childrenCount = ratingView.RatingLayout.Children.Count;
+
+		// Assert
+		Assert.NotNull(controlTemplate);
+		Assert.Equal((maximumRating * 2) + 1, visualTreeDescendantsCount);
+		Assert.Equal(maximumRating, childrenCount);
+	}
+	```
+
+## Test Isolation:
+
+- Use fresh data for each test:
+	```csharp
+	public class OrderTests
+	{
+		private static Order CreateTestOrder() =>
+			new(OrderId.New(), TestData.CreateOrderLines());
+			
+		[Fact]
+		public async Task ProcessOrder_Success()
+		{
+			var order = CreateTestOrder();
+			// Test implementation
+		}
+	}
+	```
+- Clean up resources:
+	```csharp
+	[Fact]
+	public void IsDisposedDisposeTokenSource()
+	{
+		// Arrange
+		Image testControl = new()
+		{
+			Source = new GravatarImageSource()
+		};
+
+		// Act
+		testControl.Layout(new Rect(0, 0, 37, 73));
+		var gravatarImageSource = (GravatarImageSource)testControl.Source;
+		bool isDisposedBefore = gravatarImageSource.IsDisposed;
+		gravatarImageSource.Dispose();
+		bool isDisposedAfter = gravatarImageSource.IsDisposed;
+
+		// Assert
+		Assert.True(testControl.Source is GravatarImageSource);
+		Assert.False(isDisposedBefore);
+		Assert.True(isDisposedAfter);
+	}
+	```
+
+## Best Practices:
+
+- Name tests clearly:
+	```csharp
+	// Good: Clear test names
+	[Fact]
+	public void ChangingEmailWithNoSizeDoesNotUpdateUri()
+	
+	// Avoid: Unclear names
+	[Fact]
+	public void ChangeEmail()
+	```
+- Use meaningful assertions:
+	```csharp
+	// Good: Clear assertions
+	Assert.Equal(expected, actual);
+	Assert.Contains(expectedItem, collection);
+	Assert.Throws<ArgumentOutOfRangeException>(() => new RatingView().MaximumRating = 0);
+	
+	// Avoid: Multiple assertions without context
+	Assert.NotNull(result);
+	Assert.True(result.Success);
+	Assert.Equal(0, result.Errors.Count);
+	```
+- Handle async operations properly:
+	```csharp
+	// Good: Async test method
+	[Fact]
+	public async Task ProcessOrder_ValidOrder_Succeeds()
+	{
+		await using var processor = new OrderProcessor();
+		var result = await processor.ProcessAsync(order);
+		Assert.True(result.IsSuccess);
+	}
+	
+	// Avoid: Sync over async
+	[Fact]
+	public void ProcessOrder_ValidOrder_Succeeds()
+	{
+		using var processor = new OrderProcessor();
+		var result = processor.ProcessAsync(order).Result;  // Can deadlock
+		Assert.True(result.IsSuccess);
+	}
+	```
+- Use `TestContext.Current.CancellationToken` for cancellation:
+	```csharp
+	// Good:
+	[Fact]
+	public async Task ProcessOrder_CancellationRequested()
+	{
+		await using var processor = new OrderProcessor();
+		var result = await processor.ProcessAsync(order, TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess);
+	}
+	// Avoid:
+	[Fact]
+	public async Task ProcessOrder_CancellationRequested()
+	{
+		await using var processor = new OrderProcessor();
+		var result = await processor.ProcessAsync(order, CancellationToken.None);
+		Assert.False(result.IsSuccess);
+	}
+	```
+
+## Assertions:
+
+- Use xUnit's built-in assertions:
+	```csharp
+	// Good: Using xUnit's built-in assertions
+	public class OrderTests
+	{
+		[Fact]
+		public void CalculateTotal_WithValidLines_ReturnsCorrectSum()
+		{
+			// Arrange
+			var order = new Order(
+				OrderId.New(),
+				new[]
+				{
+					new OrderLine("SKU1", 2, 10.0m),
+					new OrderLine("SKU2", 1, 20.0m)
+				});
+			
+			// Act
+			var total = order.CalculateTotal();
+			
+			// Assert
+			Assert.Equal(40.0m, total);
+		}
+		
+		[Fact]
+		public void Order_WithInvalidLines_ThrowsException()
+		{
+			// Arrange
+			var invalidLines = new OrderLine[] { };
+			
+			// Act & Assert
+			var ex = Assert.Throws<ArgumentException>(() =>
+				new Order(OrderId.New(), invalidLines));
+			Assert.Equal("Order must have at least one line", ex.Message);
+		}
+		
+		[Fact]
+		public void Order_WithValidData_HasExpectedProperties()
+		{
+			// Arrange
+			var id = OrderId.New();
+			var lines = new[] { new OrderLine("SKU1", 1, 10.0m) };
+			
+			// Act
+			var order = new Order(id, lines);
+			
+			// Assert
+			Assert.NotNull(order);
+			Assert.Equal(id, order.Id);
+			Assert.Single(order.Lines);
+			Assert.Collection(order.Lines,
+				line =>
+				{
+					Assert.Equal("SKU1", line.Sku);
+					Assert.Equal(1, line.Quantity);
+					Assert.Equal(10.0m, line.Price);
+				});
+		}
+	}
+	```
+	
+- Avoid third-party assertion libraries:
+	```csharp
+	// Avoid: Using FluentAssertions or similar libraries
+	public class OrderTests
+	{
+		[Fact]
+		public void CalculateTotal_WithValidLines_ReturnsCorrectSum()
+		{
+			var order = new Order(
+				OrderId.New(),
+				new[]
+				{
+					new OrderLine("SKU1", 2, 10.0m),
+					new OrderLine("SKU2", 1, 20.0m)
+				});
+			
+			// Avoid: Using FluentAssertions
+			order.CalculateTotal().Should().Be(40.0m);
+			order.Lines.Should().HaveCount(2);
+			order.Should().NotBeNull();
+		}
+	}
+	```
+	
+- Use proper assertion types:
+	```csharp
+	public class CustomerTests
+	{
+		[Fact]
+		public void Customer_WithValidEmail_IsCreated()
+		{
+			// Boolean assertions
+			Assert.True(customer.IsActive);
+			Assert.False(customer.IsDeleted);
+			
+			// Equality assertions
+			Assert.Equal("john@example.com", customer.Email);
+			Assert.NotEqual(Guid.Empty, customer.Id);
+			
+			// Collection assertions
+			Assert.Empty(customer.Orders);
+			Assert.Contains("Admin", customer.Roles);
+			Assert.DoesNotContain("Guest", customer.Roles);
+			Assert.All(customer.Orders, o => Assert.NotNull(o.Id));
+			
+			// Type assertions
+			Assert.IsType<PremiumCustomer>(customer);
+			Assert.IsAssignableFrom<ICustomer>(customer);
+			
+			// String assertions
+			Assert.StartsWith("CUST", customer.Reference);
+			Assert.Contains("Premium", customer.Description);
+			Assert.Matches("^CUST\\d{6}$", customer.Reference);
+			
+			// Range assertions
+			Assert.InRange(customer.Age, 18, 100);
+			
+			// Reference assertions
+			Assert.Same(expectedCustomer, actualCustomer);
+			Assert.NotSame(differentCustomer, actualCustomer);
+		}
+	}
+	```
+	
+- Use Assert.Collection for complex collections:
+	```csharp
+	[Fact]
+	public void ProcessOrder_CreatesExpectedEvents()
+	{
+		// Arrange
+		var processor = new OrderProcessor();
+		var order = CreateTestOrder();
+		
+		// Act
+		var events = processor.Process(order);
+		
+		// Assert
+		Assert.Collection(events,
+			evt =>
+			{
+				Assert.IsType<OrderReceivedEvent>(evt);
+				var received = Assert.IsType<OrderReceivedEvent>(evt);
+				Assert.Equal(order.Id, received.OrderId);
+			},
+			evt =>
+			{
+				Assert.IsType<InventoryReservedEvent>(evt);
+				var reserved = Assert.IsType<InventoryReservedEvent>(evt);
+				Assert.Equal(order.Id, reserved.OrderId);
+				Assert.NotEmpty(reserved.ReservedItems);
+			},
+			evt =>
+			{
+				Assert.IsType<OrderConfirmedEvent>(evt);
+				var confirmed = Assert.IsType<OrderConfirmedEvent>(evt);
+				Assert.Equal(order.Id, confirmed.OrderId);
+				Assert.True(confirmed.IsSuccess);
+			});
+	}
+	```

--- a/.github/prompts/prompts.prompt.md
+++ b/.github/prompts/prompts.prompt.md
@@ -4,4 +4,5 @@ Include these prompt instructions if their link's name is used.
 
 - [maui](dotnet/maui/maui.prompt.md)
 - [async](dotnet/async.prompt.md)
+- [Code Style](dotnet/codestyle.prompt.md)
 - [Testing using xUnit](dotnet/testing.xunit.prompt.md)

--- a/.github/prompts/prompts.prompt.md
+++ b/.github/prompts/prompts.prompt.md
@@ -4,3 +4,4 @@ Include these prompt instructions if their link's name is used.
 
 - [maui](dotnet/maui/maui.prompt.md)
 - [async](dotnet/async.prompt.md)
+- [Testing using xUnit](dotnet/testing.xunit.prompt.md)


### PR DESCRIPTION
Added additional prompts for .net MAUI, back-ported from the .net MAUI Community Toolkit, including:

- Testing with xUnit
- Not to use Xamarin.Forms
- Additional layout guides
- Additional code style guides